### PR TITLE
remove dependency to gbdt libralies

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install torch mlflow
+        pip install torch mlflow catboost lightgbm xgboost
     - name: Install MeCab
       run: |
         sudo apt install mecab libmecab-dev mecab-ipadic-utf8

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install torch mlflow
+        pip install torch mlflow catboost lightgbm xgboost
         pip install setuptools==42.0.2
         pip install wheel twine
     - name: Build and publish

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,10 +9,20 @@ You can install nyaggle via pip:
     pip install nyaggle
 
 
+nyaggle does not install the following packages by pip:
+
+- catboost
+- lightgbm
+- xgboost
+- mlflow
+- pytorch
+
+You need to install these packages if you want to use them through nyaggle API.
+For example, you need to install xgboost before calling ``run_experiment`` with ``algorithm_type='xgb'``.
 
 To use :code:`nyaggle.nlp.BertSentenceVectorizer`, you first need to install PyTorch.
 Please refer to `PyTorch installation page <https://pytorch.org/get-started/locally/#start-locally>`_
 to install Pytorch to your environment.
 
 If you use :code:`lang=ja` option in :code:`BertSentenceVecorizer`,
-you need to intall MeCab and mecab-python3 package to your environment.
+you also need to intall MeCab and mecab-python3 package to your environment.

--- a/nyaggle/environment.py
+++ b/nyaggle/environment.py
@@ -47,6 +47,7 @@ def requires_lightgbm():
 try:
     import catboost
     _has_catboost = True
+    # TODO check catboost version >= 0.17
 except ImportError:
     _has_catboost = False
 

--- a/nyaggle/environment.py
+++ b/nyaggle/environment.py
@@ -7,12 +7,8 @@ except ImportError:
     _has_torch = False
 
 
-def has_torch():
-    return _has_torch
-
-
 def requires_torch():
-    if not has_torch():
+    if not _has_torch:
         raise ImportError('You need to install pytorch before using this API.')
 
 
@@ -25,10 +21,51 @@ except ImportError:
     _has_mlflow = False
 
 
-def has_mlflow():
-    return _has_mlflow
-
-
 def requires_mlflow():
-    if not has_mlflow():
+    if not _has_mlflow:
         raise ImportError('You need to install mlflow before using this API.')
+
+
+# lightgbm
+
+
+try:
+    import lightgbm
+    _has_lightgbm = True
+except ImportError:
+    _has_lightgbm = False
+
+
+def requires_lightgbm():
+    if not _has_lightgbm:
+        raise ImportError('You need to install lightgbm before using this API.')
+
+
+# lightgbm
+
+
+try:
+    import catboost
+    _has_catboost = True
+except ImportError:
+    _has_catboost = False
+
+
+def requires_catboost():
+    if not _has_catboost:
+        raise ImportError('You need to install catboost before using this API.')
+
+
+# xgboost
+
+
+try:
+    import xgboost
+    _has_xgboost = True
+except ImportError:
+    _has_xgboost = False
+
+
+def requires_xgboost():
+    if not _has_xgboost:
+        raise ImportError('You need to install xgboost before using this API.')

--- a/nyaggle/experiment/run.py
+++ b/nyaggle/experiment/run.py
@@ -8,19 +8,16 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union
 import numpy as np
 import pandas as pd
 import sklearn.utils.multiclass as multiclass
-from catboost import CatBoost, CatBoostClassifier, CatBoostRegressor
-from lightgbm import LGBMModel, LGBMClassifier, LGBMRegressor
-from more_itertools import first_true
 from sklearn.base import BaseEstimator
 from sklearn.metrics import roc_auc_score, mean_squared_error, log_loss
 from sklearn.model_selection import BaseCrossValidator
-from xgboost import XGBModel, XGBClassifier, XGBRegressor
 
+from nyaggle.environment import requires_catboost, requires_lightgbm, requires_xgboost
 from nyaggle.experiment.auto_prep import autoprep_gbdt
 from nyaggle.experiment.experiment import Experiment
 from nyaggle.experiment.hyperparameter_tuner import find_best_lgbm_parameter
 from nyaggle.feature_store import load_features
-from nyaggle.util import plot_importance
+from nyaggle.util import plot_importance, is_gbdt_instance
 from nyaggle.validation.cross_validate import cross_validate
 from nyaggle.validation.split import check_cv
 
@@ -34,7 +31,6 @@ ExperimentResult = namedtuple('ExperimentResult',
                                   'time',
                                   'submission_df'
                               ])
-GBDTModel = Union[CatBoost, LGBMModel, XGBModel]
 
 
 def run_experiment(model_params: Dict[str, Any],
@@ -181,8 +177,8 @@ def run_experiment(model_params: Dict[str, Any],
     model_type, eval_func, cat_param_name = _dispatch_models(algorithm_type, type_of_target, eval_func)
 
     if with_auto_prep:
-        assert issubclass(model_type, (LGBMModel, CatBoost, XGBModel)), "with_auto_prep is only supported for gbdt"
-        X_train, X_test = autoprep_gbdt(model_type, X_train, X_test, categorical_feature)
+        assert algorithm_type in ('cat', 'xgb', 'lgbm'), "with_auto_prep is only supported for gbdt"
+        X_train, X_test = autoprep_gbdt(algorithm_type, X_train, X_test, categorical_feature)
 
     logging_directory = logging_directory.format(time=datetime.now().strftime('%Y%m%d_%H%M%S'))
 
@@ -199,7 +195,7 @@ def run_experiment(model_params: Dict[str, Any],
             exp.log_param('features', feature_list)
 
         if with_auto_hpo:
-            assert issubclass(model_type, LGBMModel), 'auto-tuning is only supported for LightGBM'
+            assert algorithm_type == 'lgbm', 'auto-tuning is only supported for LightGBM'
             model_params = find_best_lgbm_parameter(model_params, X_train, y, cv=cv, groups=groups,
                                                     type_of_target=type_of_target)
             exp.log_param('model_params_tuned', model_params)
@@ -288,38 +284,50 @@ def _dispatch_eval_func(target_type: str, custom_eval: Optional[Callable] = None
     return custom_eval if custom_eval is not None else default_eval_func[target_type]
 
 
+def _dispatch_gbdt_class(algorithm_type: str, type_of_target: str):
+    is_regression = type_of_target == 'continuous'
+
+    if algorithm_type == 'lgbm':
+        requires_lightgbm()
+        from lightgbm import LGBMClassifier, LGBMRegressor
+        return LGBMRegressor if is_regression else LGBMClassifier
+    elif algorithm_type == 'cat':
+        requires_catboost()
+        from catboost import CatBoostClassifier, CatBoostRegressor
+        return CatBoostRegressor if is_regression else CatBoostClassifier
+    else:
+        requires_xgboost()
+        assert algorithm_type == 'xgb'
+        from xgboost import XGBClassifier, XGBRegressor
+        return XGBRegressor if is_regression else XGBClassifier
+
+
 def _dispatch_models(algorithm_type: Union[str, Type[BaseEstimator]],
                      target_type: str, custom_eval: Optional[Callable] = None):
     if not isinstance(algorithm_type, str):
         assert issubclass(algorithm_type, BaseEstimator), "algorithm_type should be str or subclass of BaseEstimator"
         return algorithm_type, _dispatch_eval_func(target_type, custom_eval), None
 
-    gbdt_table = [
-        ('binary', 'lgbm', LGBMClassifier, 'categorical_feature'),
-        ('multiclass', 'lgbm', LGBMClassifier, 'categorical_feature'),
-        ('continuous', 'lgbm', LGBMRegressor, 'categorical_feature'),
-        ('binary', 'cat', CatBoostClassifier, 'cat_features'),
-        ('multiclass', 'cat', CatBoostClassifier, 'cat_features'),
-        ('continuous', 'cat', CatBoostRegressor, 'cat_features'),
-        ('binary', 'xgb', XGBClassifier, None),
-        ('multiclass', 'xgb', XGBClassifier, None),
-        ('continuous', 'xgb', XGBRegressor, None),
-    ]
-    found = first_true(gbdt_table, pred=lambda x: x[0] == target_type and x[1] == algorithm_type)
-    if found is None:
-        raise RuntimeError('Not supported gbdt_type ({}) or type_of_target ({}).'.format(algorithm_type, target_type))
+    cat_features = {
+        'lgbm': 'categorical_feature',
+        'cat': 'cat_features',
+        'xgb': None
+    }
 
-    return found[2], _dispatch_eval_func(target_type, custom_eval), found[3]
+    gbdt_class = _dispatch_gbdt_class(algorithm_type, target_type)
+    eval_func = _dispatch_eval_func(target_type, custom_eval)
+
+    return gbdt_class, eval_func, cat_features[algorithm_type]
 
 
-def _save_model(model: Union[GBDTModel, BaseEstimator], logging_directory: str, fold: int, exp: Experiment):
+def _save_model(model: BaseEstimator, logging_directory: str, fold: int, exp: Experiment):
     model_dir = os.path.join(logging_directory, 'models')
     os.makedirs(model_dir, exist_ok=True)
     path = os.path.join(model_dir, 'fold{}'.format(fold))
 
-    if isinstance(model, LGBMModel):
+    if is_gbdt_instance(model, 'lgbm'):
         model.booster_.save_model(path)
-    elif isinstance(model, (XGBModel, CatBoost)):
+    elif is_gbdt_instance(model, ('xgb', 'cat')):
         model.save_model(path)
     else:
         with open(path, "wb") as f:

--- a/nyaggle/util/__init__.py
+++ b/nyaggle/util/__init__.py
@@ -1,1 +1,2 @@
 from nyaggle.util.plot_importance import plot_importance
+from nyaggle.util.traits import is_instance, is_gbdt_instance

--- a/nyaggle/util/traits.py
+++ b/nyaggle/util/traits.py
@@ -23,8 +23,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import importlib
+from typing import List, Tuple, Union
 
-def safe_isinstance(obj, class_path_str):
+
+def is_instance(obj, class_path_str: Union[str, List, Tuple]) -> bool:
     """
     Acts as a safe version of isinstance without having to explicitly
     import packages which may not exist in the users environment.
@@ -71,6 +74,20 @@ def safe_isinstance(obj, class_path_str):
         if _class is None:
             continue
 
-        return isinstance(obj, _class)
+        if isinstance(obj, _class):
+            return True
 
     return False
+
+
+def is_gbdt_instance(obj, algorithm_type: Union[str, Tuple]) -> bool:
+    if isinstance(algorithm_type, str):
+        algorithm_type = (algorithm_type,)
+
+    gbdt_instance_name = {
+        'lgbm': 'lightgbm.sklearn.LGBMModel',
+        'xgb': 'xgboost.sklearn.XGBModel',
+        'cat': 'catboost.core.CatBoost'
+    }
+
+    return is_instance(obj, tuple(gbdt_instance_name[t] for t in algorithm_type))

--- a/nyaggle/util/traits.py
+++ b/nyaggle/util/traits.py
@@ -1,0 +1,76 @@
+# safe_instance function is originally from:
+# https://github.com/slundberg/shap/blob/master/shap/common.py
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Scott Lundberg
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def safe_isinstance(obj, class_path_str):
+    """
+    Acts as a safe version of isinstance without having to explicitly
+    import packages which may not exist in the users environment.
+    Checks if obj is an instance of type specified by class_path_str.
+    Parameters
+    ----------
+    obj: Any
+        Some object you want to test against
+    class_path_str: str or list
+        A string or list of strings specifying full class paths
+        Example: `sklearn.ensemble.RandomForestRegressor`
+    Returns
+    --------
+    bool: True if isinstance is true and the package exists, False otherwise
+    """
+    if isinstance(class_path_str, str):
+        class_path_strs = [class_path_str]
+    elif isinstance(class_path_str, list) or isinstance(class_path_str, tuple):
+        class_path_strs = class_path_str
+    else:
+        class_path_strs = ['']
+
+    # try each module path in order
+    for class_path_str in class_path_strs:
+        if "." not in class_path_str:
+            raise ValueError("class_path_str must be a string or list of strings specifying a full \
+                module path to a class. Eg, 'sklearn.ensemble.RandomForestRegressor'")
+
+        # Splits on last occurence of "."
+        module_name, class_name = class_path_str.rsplit(".", 1)
+
+        # Check module exists
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except:
+            spec = None
+        if spec is None:
+            continue
+
+        module = importlib.import_module(module_name)
+
+        # Get class
+        _class = getattr(module, class_name, None)
+        if _class is None:
+            continue
+
+        return isinstance(obj, _class)
+
+    return False

--- a/nyaggle/validation/adversarial_validate.py
+++ b/nyaggle/validation/adversarial_validate.py
@@ -3,12 +3,12 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from catboost import CatBoostClassifier
-from lightgbm import LGBMClassifier
 from sklearn.base import BaseEstimator
 from sklearn.metrics import roc_auc_score
 from sklearn.model_selection import KFold
 
+from nyaggle.environment import requires_lightgbm
+from nyaggle.util import is_instance
 from nyaggle.validation.cross_validate import cross_validate
 from nyaggle.validation.split import Take
 
@@ -66,10 +66,12 @@ def adversarial_validate(X_train: pd.DataFrame,
     y = np.array([1]*len(X_train) + [0]*len(X_test))
 
     if estimator is None:
+        requires_lightgbm()
+        from lightgbm import LGBMClassifier
         estimator = LGBMClassifier(n_estimators=10000, objective='binary', importance_type=importance_type,
                                    random_state=0)
     else:
-        assert isinstance(estimator, (LGBMClassifier, CatBoostClassifier)), \
+        assert is_instance(estimator, ('lightgbm.sklearn.LGBMModel', 'catboost.core.CatBoost')), \
             'Only CatBoostClassifier or LGBMClassifier is allowed'
 
     if cv is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-catboost>=0.17
 category_encoders
-lightgbm
 matplotlib
 more-itertools
 numpy
@@ -11,4 +9,3 @@ seaborn
 sklearn
 tqdm
 transformers
-xgboost

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,7 @@ setup(
     license='MIT',
 
     install_requires=[
-        'catboost>=0.17',
         'category_encoders',
-        'lightgbm',
         'matplotlib',
         'more-itertools',
         'numpy',
@@ -40,8 +38,7 @@ setup(
         'seaborn',
         'sklearn',
         'tqdm',
-        'transformers>=2.3.0',
-        'xgboost'
+        'transformers>=2.3.0'
     ],
     author='nyanp',
     author_email='Noumi.Taiga@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ setup(
         'tqdm',
         'transformers>=2.3.0'
     ],
+
+    extras_require={
+        'all': ['catboost>=0.17', 'lightgbm', 'xgboost', 'torch', 'mlflow']
+    },
+
     author='nyanp',
     author_email='Noumi.Taiga@gmail.com',
     url='https://github.com/nyanp/nyaggle',

--- a/tests/validation/test_cross_validate.py
+++ b/tests/validation/test_cross_validate.py
@@ -87,7 +87,7 @@ def test_cv_lgbm_df():
 
 def test_cv_cat_df():
     X, y = make_classification_df(n_samples=1024, n_num_features=20, n_cat_features=1, class_sep=0.98, random_state=0)
-    X, _ = autoprep_gbdt(CatBoostClassifier, X, None)
+    X, _ = autoprep_gbdt('cat', X, None)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=0)
 
     models = [CatBoostClassifier(n_estimators=300) for _ in range(5)]


### PR DESCRIPTION
This PR closes #38 by removing dependency to gbdt packages. In the next release, nyaggle will provide ‘all’ extra option to install them instead.