### PR TITLE
Add if_exists option to experiment, change parameter/metrics file format to json

### DIFF
--- a/docs/source/tutorial/experiment.rst
+++ b/docs/source/tutorial/experiment.rst
@@ -45,8 +45,8 @@ The ``run_experiment`` API performs cross-validation and stores artifacts to the
 
     output
     └── 20200130123456          # yyyymmssHHMMSS
-        ├── params.txt          # Parameters
-        ├── metrics.txt         # Metrics (single fold & overall CV score)
+        ├── params.json         # Parameters
+        ├── metrics.json        # Metrics (single fold & overall CV score)
         ├── oof_prediction.npy  # Out of fold prediction
         ├── test_prediction.npy # Test prediction
         ├── 20200130123456.csv  # Submission csv file

--- a/examples/kaggle-days-tokyo/kaggle_days_tokyo.py
+++ b/examples/kaggle-days-tokyo/kaggle_days_tokyo.py
@@ -46,6 +46,6 @@ run_experiment(logging_directory='baseline_kaggledays_tokyo',
                X_test=X_test,
                eval_func=mean_squared_error,
                type_of_target='continuous',
-               overwrite=True,
+               if_exists='replace',
                with_auto_hpo=True,
                sample_submission=pd.read_csv('sample_submission.csv'))

--- a/nyaggle/experiment/experiment.py
+++ b/nyaggle/experiment/experiment.py
@@ -42,6 +42,10 @@ def _check_directory(directory: str, if_exists: str) -> str:
     return directory
 
 
+def _sanitize(v):
+    return v if isinstance(v, numbers.Number) else str(v)
+
+
 class Experiment(object):
     """Minimal experiment logger for Kaggle
 
@@ -99,7 +103,6 @@ class Experiment(object):
             self.logger.addHandler(FileHandler(self.log_path))
             self.logger.setLevel(DEBUG)
             self.is_custom = False
-        self.metrics_path = os.path.join(logging_directory, 'metrics.txt')
         self.metrics = self._load_dict('metrics.json')
         self.params = self._load_dict('params.json')
         self.inherit_existing_run = False
@@ -223,9 +226,6 @@ class Experiment(object):
         """
         self.logger.info(text)
 
-    def _sanitize(self, v):
-        return v if isinstance(v, numbers.Number) else str(v)
-
     def log_param(self, key, value):
         """
         Logs a key-value pair for the experiment.
@@ -234,8 +234,8 @@ class Experiment(object):
             key: parameter name
             value: parameter value
         """
-        key = self._sanitize(key)
-        value = self._sanitize(value)
+        key = _sanitize(key)
+        value = _sanitize(value)
         self.params[key] = value
 
         if self.with_mlflow:

--- a/nyaggle/experiment/experiment.py
+++ b/nyaggle/experiment/experiment.py
@@ -30,6 +30,13 @@ def _check_directory(directory: str, if_exists: str) -> str:
         elif if_exists == 'replace':
             warnings.warn(
                 'directory {} already exists. It will be replaced by the new result'.format(directory))
+
+            existing_run_id = _try_to_get_existing_mlflow_run_id(directory)
+            if existing_run_id is not None:
+                requires_mlflow()
+                import mlflow
+                mlflow.delete_run(existing_run_id)
+
             shutil.rmtree(directory, ignore_errors=True)
         elif if_exists == 'rename':
             postfix_index = 1
@@ -151,6 +158,7 @@ class Experiment(object):
                 'experiment_id': active_run.info.experiment_id,
                 'run_id': active_run.info.run_id
             }
+            self.mlflow_run_id = active_run.info.run_id
             with open(os.path.join(self.logging_directory, 'mlflow.json'), 'w') as f:
                 json.dump(mlflow_metadata, f, indent=4)
 

--- a/nyaggle/experiment/run.py
+++ b/nyaggle/experiment/run.py
@@ -37,7 +37,7 @@ def run_experiment(model_params: Dict[str, Any],
                    X_train: pd.DataFrame, y: pd.Series,
                    X_test: Optional[pd.DataFrame] = None,
                    logging_directory: str = 'output/{time}',
-                   overwrite: bool = False,
+                   if_exists: str = 'error',
                    eval_func: Optional[Callable] = None,
                    algorithm_type: Union[str, Type[BaseEstimator]] = 'lgbm',
                    fit_params: Optional[Union[Dict[str, Any], Callable]] = None,
@@ -92,8 +92,12 @@ def run_experiment(model_params: Dict[str, Any],
             Test data (Optional). If specified, prediction on the test data is performed using ensemble of models.
         logging_directory:
             Path to directory where output of experiment is stored.
-        overwrite:
-            If True, contents in ``logging_directory`` will be overwritten.
+        if_exists:
+            How to behave if the logging directory already exists.
+            - error: Raise a ValueError.
+            - replace: Delete logging directory before logging.
+            - append: Append to exisitng experiment.
+            - rename: Rename current directory by adding "_1", "_2"... prefix
         fit_params:
             Parameters passed to the fit method of the estimator. If dict is passed, the same parameter except
             eval_set passed for each fold. If callable is passed,
@@ -182,7 +186,7 @@ def run_experiment(model_params: Dict[str, Any],
 
     logging_directory = logging_directory.format(time=datetime.now().strftime('%Y%m%d_%H%M%S'))
 
-    with Experiment(logging_directory, overwrite, with_mlflow=with_mlflow) as exp:
+    with Experiment(logging_directory, if_exists=if_exists, with_mlflow=with_mlflow) as exp:
         exp.log('Algorithm: {}'.format(algorithm_type))
         exp.log('Experiment: {}'.format(logging_directory))
         exp.log('Params: {}'.format(model_params))

--- a/nyaggle/experiment/run.py
+++ b/nyaggle/experiment/run.py
@@ -75,8 +75,8 @@ def run_experiment(model_params: Dict[str, Any],
           oof_prediction.npy       <== Out of fold prediction in numpy array format
           test_prediction.npy      <== Test prediction in numpy array format
           submission.csv           <== Submission csv file
-          metrics.txt              <== Metrics
-          params.txt               <== Parameters
+          metrics.json             <== Metrics
+          params.json              <== Parameters
           models/
               fold1                <== The trained model in fold 1
               ...

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -1,4 +1,6 @@
+import json
 import os
+
 from nyaggle.experiment import Experiment
 from nyaggle.testing import get_temp_directory
 
@@ -12,13 +14,7 @@ def test_experiment_continue():
         with Experiment.continue_from(logging_dir) as e:
             e.log_metric('LB', 0.95)
 
-            metric_file = os.path.join(logging_dir, 'metrics.txt')
-
-            with open(metric_file, 'r') as f:
-                lines = [line.split(',') for line in f.readlines()]
-
-                assert lines[0][0] == 'CV'
-                assert lines[1][0] == 'LB'
+            metric_file = os.path.join(logging_dir, 'metrics.json')
 
             import mlflow
 
@@ -26,3 +22,8 @@ def test_experiment_continue():
             data = client.get_run(mlflow.active_run().info.run_id).data
             assert data.metrics['CV'] == 0.97
             assert data.metrics['LB'] == 0.95
+
+        with open(metric_file, 'r') as f:
+            obj = json.load(f)
+            assert obj['CV'] == 0.97
+            assert obj['LB'] == 0.95

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -1,8 +1,218 @@
 import json
 import os
+import pytest
+
+import pandas as pd
+import numpy as np
 
 from nyaggle.experiment import Experiment
 from nyaggle.testing import get_temp_directory
+
+
+def test_log_params():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir) as e:
+            e.log_param('x', 1)
+            e.log_param('x', 2)
+            e.log_params({
+                'y': 'ABC',
+                'z': None,
+            })
+
+        with open(os.path.join(logging_dir, 'params.json'), 'r') as f:
+            params = json.load(f)
+
+            expected = {
+                'x': 2,      # if the key is duplicated, the latter one is stored
+                'y': 'ABC',
+                'z': 'None'  # all non-numerical values are casted to string before logging
+            }
+            assert params == expected
+
+
+def test_log_params_empty():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir):
+            pass
+
+        with open(os.path.join(logging_dir, 'params.json'), 'r') as f:
+            params = json.load(f)
+            assert params == {}
+
+
+def test_log_metrics():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir) as e:
+            e.log_metric('x', 1)
+            e.log_metric('x', 2)
+
+        with open(os.path.join(logging_dir, 'metrics.json'), 'r') as f:
+            params = json.load(f)
+
+            expected = {
+                'x': 2
+            }
+            assert params == expected
+
+
+def test_log_metrics_empty():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir):
+            pass
+
+        with open(os.path.join(logging_dir, 'metrics.json'), 'r') as f:
+            params = json.load(f)
+            assert params == {}
+
+
+def test_error_while_experiment():
+    with get_temp_directory() as logging_dir:
+        try:
+            with Experiment(logging_dir) as e:
+                e.log_metric('x', 0.5)
+                e.log_param('foo', 'bar')
+                e.log_numpy('np', np.zeros(100))
+                e.log_dataframe('df', pd.DataFrame({'a': [1, 2, 3]}))
+
+                raise KeyboardInterrupt()
+        except KeyboardInterrupt:
+            pass
+
+        # all logs are saved even if error raised inside experiment
+        with open(os.path.join(logging_dir, 'metrics.json'), 'r') as f:
+            metrics = json.load(f)
+            assert metrics == {'x': 0.5}
+
+        with open(os.path.join(logging_dir, 'params.json'), 'r') as f:
+            params = json.load(f)
+            assert params == {'foo': 'bar'}
+
+        assert os.path.exists(os.path.join(logging_dir, 'np.npy'))
+        assert os.path.exists(os.path.join(logging_dir, 'df.f'))
+
+
+def test_experiment_duplicated_error():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir) as e:
+            e.log_metric('CV', 0.97)
+
+        with pytest.raises(ValueError):
+            with Experiment(logging_dir):
+                pass
+
+        with pytest.raises(ValueError):
+            with Experiment(logging_dir, if_exists='error'):
+                pass
+
+
+def test_experiment_duplicated_replace():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir) as e:
+            e.log_metric('CV', 0.97)
+
+        with Experiment(logging_dir, if_exists='replace') as e:
+            e.log_metric('LB', 0.95)
+
+        with open(os.path.join(logging_dir, 'metrics.json')) as f:
+            metrics = json.load(f)
+
+            # replaced by the new result
+            assert 'LB' in metrics
+            assert 'CV' not in metrics
+
+
+def test_experiment_duplicated_append():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir) as e:
+            e.log_metric('CV', 0.97)
+
+        with Experiment(logging_dir, if_exists='append') as e:
+            e.log_metric('LB', 0.95)
+
+        with open(os.path.join(logging_dir, 'metrics.json')) as f:
+            metrics = json.load(f)
+
+            # appended to the existing result
+            assert 'LB' in metrics
+            assert 'CV' in metrics
+
+
+def test_experiment_duplicated_rename():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir) as e:
+            e.log_metric('CV', 0.97)
+
+        with Experiment(logging_dir, if_exists='rename') as e:
+            e.log_metric('LB', 0.95)
+
+        with open(os.path.join(logging_dir, 'metrics.json')) as f:
+            metrics = json.load(f)
+            assert 'LB' not in metrics
+            assert 'CV' in metrics
+
+        with open(os.path.join(logging_dir + '_1', 'metrics.json')) as f:
+            metrics = json.load(f)
+            assert 'LB' in metrics
+            assert 'CV' not in metrics
+
+
+def test_experiment_duplicated_replace_mlflow():
+    import mlflow
+
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir, with_mlflow=True) as e:
+            e.log_metric('CV', 0.97)
+            run_id_old = e.mlflow_run_id
+
+        with Experiment(logging_dir, with_mlflow=True, if_exists='replace') as e:
+            e.log_metric('LB', 0.95)
+            run_id_new = e.mlflow_run_id
+
+        assert run_id_old != run_id_new
+
+        client = mlflow.tracking.MlflowClient()
+        old_run = client.get_run(run_id_old)
+        new_run = client.get_run(run_id_new)
+        assert old_run.info.lifecycle_stage == 'deleted'
+        assert new_run.info.lifecycle_stage == 'active'
+
+
+def test_experiment_duplicated_append_mlflow():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir, with_mlflow=True) as e:
+            e.log_metric('CV', 0.97)
+            run_id_old = e.mlflow_run_id
+
+        with Experiment(logging_dir, with_mlflow=True, if_exists='append') as e:
+            e.log_metric('LB', 0.95)
+            run_id_new = e.mlflow_run_id
+
+        with open(os.path.join(logging_dir, 'metrics.json')) as f:
+            metrics = json.load(f)
+
+            # appended to the existing result
+            assert 'LB' in metrics
+            assert 'CV' in metrics
+
+        assert run_id_old == run_id_new
+
+        import mlflow
+        client = mlflow.tracking.MlflowClient()
+        old_run = client.get_run(run_id_old)
+        assert old_run.info.lifecycle_stage == 'active'
+
+
+def test_experiment_duplicated_rename_mlflow():
+    with get_temp_directory() as logging_dir:
+        with Experiment(logging_dir, with_mlflow=True) as e:
+            e.log_metric('CV', 0.97)
+            run_id_old = e.mlflow_run_id
+
+        with Experiment(logging_dir, with_mlflow=True, if_exists='rename') as e:
+            e.log_metric('LB', 0.95)
+            run_id_new = e.mlflow_run_id
+
+        assert run_id_old != run_id_new
 
 
 def test_experiment_continue():

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -11,7 +11,7 @@ def test_experiment_continue():
             e.log_metric('CV', 0.97)
 
         # appending to exising local & mlflow result
-        with Experiment.continue_from(logging_dir) as e:
+        with Experiment.continue_from(logging_dir, with_mlflow=True) as e:
             e.log_metric('LB', 0.95)
 
             metric_file = os.path.join(logging_dir, 'metrics.json')
@@ -27,3 +27,24 @@ def test_experiment_continue():
             obj = json.load(f)
             assert obj['CV'] == 0.97
             assert obj['LB'] == 0.95
+
+        with Experiment(logging_dir, with_mlflow=True, if_exists='append') as e:
+            e.log_metric('X', 1.1)
+
+            import mlflow
+
+            client = mlflow.tracking.MlflowClient()
+            data = client.get_run(mlflow.active_run().info.run_id).data
+            assert data.metrics['CV'] == 0.97
+            assert data.metrics['LB'] == 0.95
+            assert data.metrics['X'] == 1.1
+
+        # stop logging to mlflow, still continue logging on local dir
+        with Experiment.continue_from(logging_dir, with_mlflow=False) as e:
+            e.log_metric('Y', 1.1)
+            import mlflow
+            assert mlflow.active_run() is None
+
+        with open(metric_file, 'r') as f:
+            obj = json.load(f)
+            assert 'Y' in obj

--- a/tests/experiment/test_run.py
+++ b/tests/experiment/test_run.py
@@ -16,7 +16,13 @@ from nyaggle.feature_store import save_feature
 from nyaggle.testing import make_classification_df, make_regression_df, get_temp_directory
 
 
-def _check_file_exists(directory, files):
+def _check_file_exists(directory, submission_filename=None, with_mlflow=False):
+    files = ['oof_prediction.npy', 'test_prediction.npy', 'metrics.json', 'params.json']
+    if submission_filename:
+        files.append(submission_filename)
+    if with_mlflow:
+        files.append('mlflow.json')
+
     for f in files:
         assert os.path.exists(os.path.join(directory, f)), 'File not found: {}'.format(f)
 
@@ -40,7 +46,7 @@ def test_experiment_lgb_classifier():
         assert roc_auc_score(y_train, result.oof_prediction) >= 0.9
         assert roc_auc_score(y_test, result.test_prediction) >= 0.9
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_lgb_regressor():
@@ -61,7 +67,7 @@ def test_experiment_lgb_regressor():
         assert len(np.unique(result.test_prediction)) > 5
         assert mean_squared_error(y_train, result.oof_prediction) == result.metrics[-1]
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_lgb_multiclass():
@@ -83,7 +89,7 @@ def test_experiment_lgb_multiclass():
         assert result.oof_prediction.shape == (len(y_train), 5)
         assert result.test_prediction.shape == (len(y_test), 5)
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_cat_classifier():
@@ -107,7 +113,7 @@ def test_experiment_cat_classifier():
         assert roc_auc_score(y_test, result.test_prediction) >= 0.9
         assert list(pd.read_csv(os.path.join(temp_path, 'submission.csv')).columns) == ['id', 'tgt']
 
-        _check_file_exists(temp_path, ('submission.csv', 'oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_cat_regressor():
@@ -125,7 +131,7 @@ def test_experiment_cat_regressor():
         result = run_experiment(params, X_train, y_train, X_test, temp_path, algorithm_type='cat')
 
         assert mean_squared_error(y_train, result.oof_prediction) == result.metrics[-1]
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_cat_multiclass():
@@ -148,7 +154,7 @@ def test_experiment_cat_multiclass():
 
         assert list(pd.read_csv(os.path.join(temp_path, 'submission.csv')).columns) == ['id', '0', '1', '2', '3', '4']
 
-        _check_file_exists(temp_path, ('submission.csv', 'oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path, submission_filename='submission.csv')
 
 
 def test_experiment_xgb_classifier():
@@ -172,7 +178,7 @@ def test_experiment_xgb_classifier():
         assert roc_auc_score(y_test, result.test_prediction) >= 0.9
         assert list(pd.read_csv(os.path.join(temp_path, 'submission.csv')).columns) == ['id', 'tgt']
 
-        _check_file_exists(temp_path, ('submission.csv', 'oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path, submission_filename='submission.csv')
 
 
 def test_experiment_xgb_regressor():
@@ -190,7 +196,7 @@ def test_experiment_xgb_regressor():
         result = run_experiment(params, X_train, y_train, X_test, temp_path, algorithm_type='xgb', with_auto_prep=True)
 
         assert mean_squared_error(y_train, result.oof_prediction) == result.metrics[-1]
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_xgb_multiclass():
@@ -214,7 +220,7 @@ def test_experiment_xgb_multiclass():
 
         assert list(pd.read_csv(os.path.join(temp_path, 'submission.csv')).columns) == ['id', '0', '1', '2', '3', '4']
 
-        _check_file_exists(temp_path, ('submission.csv', 'oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path, submission_filename='submission.csv')
 
 
 def test_experiment_sklearn_classifier():
@@ -236,7 +242,7 @@ def test_experiment_sklearn_classifier():
         assert roc_auc_score(y_train, result.oof_prediction) >= 0.8
         assert roc_auc_score(y_test, result.test_prediction) >= 0.8
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_sklearn_regressor():
@@ -257,7 +263,7 @@ def test_experiment_sklearn_regressor():
         assert len(np.unique(result.test_prediction)) > 5
         assert mean_squared_error(y_train, result.oof_prediction) == result.metrics[-1]
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_sklearn_multiclass():
@@ -279,7 +285,7 @@ def test_experiment_sklearn_multiclass():
         assert result.oof_prediction.shape == (len(y_train), 5)
         assert result.test_prediction.shape == (len(y_test), 5)
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_cat_custom_eval():
@@ -299,7 +305,7 @@ def test_experiment_cat_custom_eval():
                                 algorithm_type='cat', eval_func=mean_absolute_error)
 
         assert mean_absolute_error(y_train, result.oof_prediction) == result.metrics[-1]
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'test_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_without_test_data():
@@ -317,7 +323,7 @@ def test_experiment_without_test_data():
         result = run_experiment(params, X_train, y_train, None, temp_path)
 
         assert roc_auc_score(y_train, result.oof_prediction) >= 0.9
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'metrics.txt'))
+        _check_file_exists(temp_path)
 
 
 def test_experiment_fit_params():
@@ -357,7 +363,7 @@ def test_experiment_mlflow():
     with get_temp_directory() as temp_path:
         run_experiment(params, X_train, y_train, None, temp_path, with_mlflow=True)
 
-        _check_file_exists(temp_path, ('oof_prediction.npy', 'metrics.txt', 'mlflow.json'))
+        _check_file_exists(temp_path, with_mlflow=True)
 
         # test if output files are also stored in the mlflow artifact uri
         with open(os.path.join(temp_path, 'mlflow.json'), 'r') as f:
@@ -365,7 +371,7 @@ def test_experiment_mlflow():
             p = unquote(urlparse(mlflow_meta['artifact_uri']).path)
             if os.name == 'nt' and p.startswith("/"):
                 p = p[1:]
-            _check_file_exists(p, ('oof_prediction.npy', 'metrics.txt'))
+            _check_file_exists(p, with_mlflow=False)
 
 
 def test_experiment_already_exists():
@@ -380,13 +386,13 @@ def test_experiment_already_exists():
     }
 
     with get_temp_directory() as temp_path:
-        run_experiment(params, X_train, y_train, None, temp_path, overwrite=True)
+        run_experiment(params, X_train, y_train, None, temp_path)
 
-        # result is overwrited by default
-        run_experiment(params, X_train, y_train, None, temp_path, overwrite=True)
+        # result is not overwrited by default
+        run_experiment(params, X_train, y_train, None, temp_path, if_exists='replace')
 
         with pytest.raises(Exception):
-            run_experiment(params, X_train, y_train, None, temp_path, overwrite=False)
+            run_experiment(params, X_train, y_train, None, temp_path)
 
 
 def test_submission_filename():


### PR DESCRIPTION
This PR provides more choices when logging_directory already exists. params and metrics are now saved as json instead of text.