### PR TITLE
add inherit_experiment parameter to run_experiment

### DIFF
--- a/docs/source/tutorial/experiment_advanced.rst
+++ b/docs/source/tutorial/experiment_advanced.rst
@@ -53,3 +53,24 @@ If you are familiar with mlflow tracking, you may notice that these APIs are sim
       # logging as you want, and you can see the result in mlflow ui
       ...
 
+
+
+Log extra parameters to run_experiment
+---------------------------------------
+
+By using ``inherit_experiment`` parameter, you can mix any additional logging with the results ``run_experiment`` will create.
+In the following example, nyaggle records the result of ``run_experiment`` under the same experiment as
+the parameter and metrics written outside of the function.
+
+.. code-block:: python
+
+  from nyaggle.experiment import Experiment, run_experiment
+
+  with Experiment(logging_directory='./output/') as exp:
+
+      exp.log_param('my extra param', 'bar')
+
+      run_experiment(..., inherit_experiment=exp)
+
+      exp.log_metrics('my extra metrics', 0.999)
+

--- a/tests/experiment/test_run.py
+++ b/tests/experiment/test_run.py
@@ -11,7 +11,7 @@ from sklearn.metrics import roc_auc_score, mean_squared_error, mean_absolute_err
 from sklearn.model_selection import GroupKFold, KFold, train_test_split
 from sklearn.neighbors import KNeighborsClassifier
 
-from nyaggle.experiment import run_experiment
+from nyaggle.experiment import Experiment, run_experiment
 from nyaggle.feature_store import save_feature
 from nyaggle.testing import make_classification_df, make_regression_df, get_temp_directory
 
@@ -634,3 +634,18 @@ def test_inherit_outer_scope_run():
     assert data.metrics['Overall'] > 0  # recorded
 
     mlflow.end_run()
+
+
+def test_custom_experiment():
+    params = {
+        'objective': 'binary',
+        'max_depth': 8
+    }
+    X, y = make_classification_df()
+
+    with get_temp_directory() as temp_path:
+        with Experiment(temp_path, with_mlflow=True) as e:
+            run_experiment(params, X, y, logging_directory='foobar', inherit_experiment=e)
+
+        # all files are logged into e.logging_directory, instead of 'foobar'
+        _check_file_exists(temp_path, with_mlflow=True)


### PR DESCRIPTION
This PR aims to expand the flexibility of `run_experiment` API by adding `inherit_experiment` parameter to it. Now we can mix user-defined logging code with run_experiment.