### PR TITLE
Implement log_metrics for Experiment

### DIFF
--- a/nyaggle/experiment/experiment.py
+++ b/nyaggle/experiment/experiment.py
@@ -276,6 +276,16 @@ class Experiment(object):
             import mlflow
             mlflow.log_metric(name, score)
 
+    def log_metrics(self, metrics: Dict):
+        """
+        Log a batch of metrics under the logging directory.
+
+        Args:
+            metrics: dictionary of metrics.
+        """
+        for k, v in metrics.items():
+            self.log_metric(k, v)
+
     def log_numpy(self, name: str, array: np.ndarray):
         """
         Log a numpy ndarray under the logging directory.

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -45,12 +45,18 @@ def test_log_metrics():
         with Experiment(logging_dir) as e:
             e.log_metric('x', 1)
             e.log_metric('x', 2)
+            e.log_metrics({
+                'y': 3,
+                'z': 4,
+            })
 
         with open(os.path.join(logging_dir, 'metrics.json'), 'r') as f:
             params = json.load(f)
 
             expected = {
-                'x': 2
+                'x': 2,
+                'y': 3,
+                'z': 4,
             }
             assert params == expected
 


### PR DESCRIPTION
This PR implements `log_metrics` for `Experiment` to allow users to log multiple metrics at once.