### PR TITLE
Ignore catboost_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ nyaggle.egg-info/
 __pycache__/
 .pytest_cache/
 mlruns/
+catboost_info


### PR DESCRIPTION
When running the tests, catboost creates a folder named `catboost_info`. This folder should be ignored.