### PR TITLE
Fix error in bert.py

### DIFF
--- a/nyaggle/feature/nlp/bert.py
+++ b/nyaggle/feature/nlp/bert.py
@@ -53,8 +53,9 @@ class BertSentenceVectorizer(BaseFeaturizer):
             self.tokenizer = transformers.BertTokenizer.from_pretrained('bert-base-uncased')
             self.model = transformers.BertModel.from_pretrained('bert-base-uncased')
         elif lang == 'jp':
-            self.tokenizer = transformers.BertJapaneseTokenizer.from_pretrained('bert-base-japanese-whole-word-masking')
-            self.model = transformers.BertModel.from_pretrained('bert-base-japanese-whole-word-masking')
+            pretrained_model_name = 'cl-tohoku/bert-base-japanese-whole-word-masking'
+            self.tokenizer = transformers.BertJapaneseTokenizer.from_pretrained(pretrained_model_name)
+            self.model = transformers.BertModel.from_pretrained(pretrained_model_name)
         else:
             raise ValueError('Specified language type () is invalid.'.format(lang))
 

--- a/nyaggle/feature/nlp/bert.py
+++ b/nyaggle/feature/nlp/bert.py
@@ -50,8 +50,9 @@ class BertSentenceVectorizer(BaseFeaturizer):
             self.tokenizer = tokenizer
             self.model = model
         if lang == 'en':
-            self.tokenizer = transformers.BertTokenizer.from_pretrained('bert-base-uncased')
-            self.model = transformers.BertModel.from_pretrained('bert-base-uncased')
+            pretrained_model_name = 'bert-base-uncased'
+            self.tokenizer = transformers.BertTokenizer.from_pretrained(pretrained_model_name)
+            self.model = transformers.BertModel.from_pretrained(pretrained_model_name)
         elif lang == 'jp':
             pretrained_model_name = 'cl-tohoku/bert-base-japanese-whole-word-masking'
             self.tokenizer = transformers.BertJapaneseTokenizer.from_pretrained(pretrained_model_name)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ mlflow
 catboost
 lightgbm
 xgboost
-mecab-python3
+mecab-python3==0.996.6rc2
 flake8
 pytest


### PR DESCRIPTION
This is a fix for [this error](https://github.com/nyanp/nyaggle/actions/runs/182194707).

This error was caused by changes to the pretrained_models listed below.
[transformers - pretrained_models](https://github.com/huggingface/transformers/blob/master/docs/source/pretrained_models.rst)

| Change Before  |  Change After  |
| ---- | ---- |
|  **bert-base-japanese-whole-word-masking**  |  **cl-tohoku/bert-base-japanese-whole-word-masking**  |
