### PR TITLE
Japanese bert model of transformers library requires the fugashi library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyarrow
 seaborn
 sklearn
 tqdm
-transformers
+transformers["ja"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyarrow
 seaborn
 sklearn
 tqdm
-transformers["ja"]
+transformers[ja]


### PR DESCRIPTION
> Use pip install transformers["ja"] (or pip install -e .["ja"] if you install from source) to install them.
https://github.com/huggingface/transformers/blob/master/docs/source/pretrained_models.rst

The reason for the ci error is that the changes in #83 have not been incorporated.