### PR TITLE
Drop python v3.5 support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.5'
+        python-version: '3.6'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     keywords='nyaggle kaggle',
     classifiers=[
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'


### PR DESCRIPTION
### ChangeList
- Removed Python 3.5 from in github_actions
- Removed Python 3.5 from the classifiers in setup.py

### Reference
- #86
- https://github.com/nyanp/nyaggle/issues/44
- https://github.com/nyanp/nyaggle/pull/46