### PR TITLE
Rename 'sklearn' to 'scikit-learn'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ optuna>=1.0.0
 pandas
 pyarrow
 seaborn
-sklearn
+scikit-learn
 tqdm
 transformers[ja]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'pandas',
         'pyarrow',
         'seaborn',
-        'sklearn',
+        'scikit-learn',
         'tqdm',
         'transformers>=2.3.0',
     ],


### PR DESCRIPTION
Because the ``sklearn`` PyPI package is deprecated.
``nyaggle`` can not be installed without renaming the package.

```sh
$ pip install nyaggle
...(snip)...

Collecting sklearn
  Using cached sklearn-0.0.post1.tar.gz (3.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.

...(snip)...
```