### PR TITLE
fix stacking

### DIFF
--- a/tests/ensemble/test_stacking.py
+++ b/tests/ensemble/test_stacking.py
@@ -1,12 +1,12 @@
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.linear_model import Ridge, LogisticRegression
-from sklearn.metrics import roc_auc_score
+from sklearn.metrics import mean_squared_error, roc_auc_score
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC, SVR
 from sklearn.utils.multiclass import type_of_target
 
 from nyaggle.ensemble import stacking
-from nyaggle.testing import make_classification_df
+from nyaggle.testing import make_classification_df, make_regression_df
 from nyaggle.validation import cross_validate
 
 
@@ -29,14 +29,27 @@ def _make_1st_stage_preds(X, y, X_test):
     return [r.oof_prediction for r in results], [r.test_prediction for r in results]
 
 
-def test_stacking():
+def test_stacking_classification():
     X, y = make_classification_df()
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
     oof, test = _make_1st_stage_preds(X_train, y_train, X_test)
 
-    worst_base_roc = min(roc_auc_score(y_train, oof[0]), roc_auc_score(y_train, oof[1]), roc_auc_score(y_train, oof[2]))
+    worst_base_roc = min(roc_auc_score(y_train, _oof) for _oof in oof)
 
     result = stacking(test, oof, y_train, eval_func=roc_auc_score)
 
     assert roc_auc_score(y_train, result.oof_prediction) > worst_base_roc
+
+
+def test_stacking_regression():
+    X, y = make_regression_df()
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    oof, test = _make_1st_stage_preds(X_train, y_train, X_test)
+
+    worst_base_rmse = max(mean_squared_error(y_train, _oof) for _oof in oof)
+
+    result = stacking(test, oof, y_train, eval_func=mean_squared_error)
+
+    assert mean_squared_error(y_train, result.oof_prediction) < worst_base_rmse


### PR DESCRIPTION
fixed some bugs of `stacking()`.

1. pass `type_of_target` argument of `stacking()` to `cross_validate()`.
    - By default, the type_of_target of `cross_validate()` is determined by [`sklearn.utils.multiclass.type_of_target`](https://scikit-learn.org/stable/modules/generated/sklearn.utils.multiclass.type_of_target.html). Because of this, even if you set `type_of_target="continuous"` for regression with integer targets, `cross_validate()`'s `type_of_target` is `"multiclass"`.
1. fixed default estimator for regression.
    - to adapt to removal of `normalize` argument
    - [related issue](https://github.com/scikit-learn/scikit-learn/issues/3020)
    - add unittest.
3. fixed default estimator for classification.
    - add `solver="liblinear"` to adapt to change of the default value.
    - [related article](https://qiita.com/idontwannawork/items/86c5b833cdc0a4cf58b5)